### PR TITLE
Fix implicit conversion between unsigned and signed immediates

### DIFF
--- a/fixtures/fizz_buzz.mass
+++ b/fixtures/fizz_buzz.mass
@@ -42,7 +42,7 @@ print :: (integer : s32) -> () {
 
 fizz_buzz :: () -> () {
   stdout_handle := GetStdHandle(-11)
-  for i : s32 = 1, i <= 100, i = i + 1 {
+  for i : s8 = 1, i <= 100, i = i + 1 {
     print_number := true
     if (i % 3 == 0) {
       print_number = false

--- a/function.c
+++ b/function.c
@@ -971,7 +971,7 @@ compare(
 ) {
   Array_Instruction *instructions = &builder->code_block.instructions;
   assert(descriptor_is_integer(a->descriptor));
-  assert(descriptor_is_integer(b->descriptor));
+  assert(same_value_type_or_can_implicitly_move_cast(a, b));
 
   switch(operation) {
     case Compare_Type_Equal: {

--- a/value.c
+++ b/value.c
@@ -1577,6 +1577,31 @@ same_value_type_or_can_implicitly_move_cast(
     if (descriptor_byte_size(target->descriptor) > descriptor_byte_size(source->descriptor)) {
       return true;
     }
+    if (operand_is_immediate(&source->operand)) {
+
+      #define ACCEPT_IF_INTEGER_IMMEDIATE_FITS(_SOURCE_TYPE_, _TARGET_TYPE_)\
+        if (source->descriptor == &descriptor_##_SOURCE_TYPE_) {\
+          assert(target->descriptor == &descriptor_##_TARGET_TYPE_);\
+          return _SOURCE_TYPE_##_fits_into_##_TARGET_TYPE_(\
+            operand_immediate_memory_as_##_SOURCE_TYPE_(&source->operand)\
+          );\
+        }
+
+      if (descriptor_is_signed_integer(target->descriptor)) {
+        ACCEPT_IF_INTEGER_IMMEDIATE_FITS(u8, s8)
+        ACCEPT_IF_INTEGER_IMMEDIATE_FITS(u16, s16)
+        ACCEPT_IF_INTEGER_IMMEDIATE_FITS(u32, s32)
+        ACCEPT_IF_INTEGER_IMMEDIATE_FITS(u64, s64)
+      } else {
+        assert(descriptor_is_unsigned_integer(target->descriptor));
+        ACCEPT_IF_INTEGER_IMMEDIATE_FITS(s8, u8)
+        ACCEPT_IF_INTEGER_IMMEDIATE_FITS(s16, u16)
+        ACCEPT_IF_INTEGER_IMMEDIATE_FITS(s32, u32)
+        ACCEPT_IF_INTEGER_IMMEDIATE_FITS(s64, u64)
+      }
+
+      #undef ACCEPT_IF_INTEGER_IMMEDIATE_FITS
+    }
   }
   return false;
 }


### PR DESCRIPTION
While testing #2 I have discovered a crash when comparing a signed integer with the same size unsigned immediate which this PR fixes.

The actual #2 seem to not be reproducible anymore as well. 